### PR TITLE
Problem with ‘git status’ exiting with nonzero status

### DIFF
--- a/darcs-to-git
+++ b/darcs-to-git
@@ -311,7 +311,6 @@ class DarcsPatch
     puts "=" * 80
 
     pull
-    puts output_of("git", "status")
     commit_to_git_repo
   end
 


### PR DESCRIPTION
This prevents darcs-to-git from running.  Deleting the invocation of ‘git status’ makes it work again.  You may want to ignore the exit status of ‘git status’ if you want to keep the invocation.

<pre>
hoga:~ daniel$ git --version
git version 1.6.6
hoga:~ daniel$ uname -a
Darwin hoga.local 10.4.0 Darwin Kernel Version 10.4.0: Fri Apr 23 18:28:53 PDT 2010; root:xnu-1504.7.4~1/RELEASE_I386 i386
hoga:~ daniel$ git status
# On branch master
nothing to commit (working directory clean)
hoga:~ daniel$ echo $?
1
</pre>


Thanks for a great conversion script by the way! I really appreciated the well-written README file. :)
