### PR TITLE
Ask user on git errors

### DIFF
--- a/darcs-to-git
+++ b/darcs-to-git
@@ -357,6 +357,10 @@ class DarcsPatch
       commit_id = output_of("git", "log", "-n1", "--no-color").scan(/^commit ([a-z0-9]+$)/).flatten.first
       COMMIT_HISTORY.record_git_commit(commit_id, identifier)
     end
+    rescue RuntimeError => error
+      STDERR.write "An error occurred: " + error + "\n"
+      STDERR.write "Do you want to continue ? (y/N): "
+      exit unless (STDIN.getc.chr.downcase == "y")
   end
 
   def darcs_date_to_git_date(utc,local)


### PR DESCRIPTION
Hello,

On importing a darcs repository, i had a non critical error on a git command:

Running: ["git", "tag", "-a", "-m", "TAG 0.2\n\ndarcs-hash:20080421160810-d61e2-c20fe32983a55557b721b0bfa30c56916ba71a87.gz", "0_2"]
fatal: tag '0_2' already exists

And the import stopped there. That is why i propose a mechanism to handle theses error and ask to the user if he want to continue the import anyway or not.

Feel free to pull or not :)

Best regards,

Vincent
