### PR TITLE
little change after failed import

### DIFF
--- a/darcs-to-git
+++ b/darcs-to-git
@@ -293,7 +293,7 @@ class DarcsPatch
 
   def safe_patch_name(darcs_name)
     # See 'man git-check-ref-format'
-    darcs_name.gsub(/(?:[\s:*]+|\.{2,}|\#\{|^\.|\.$)/, '_')
+    darcs_name.gsub(/(?:[\s:*]+|\.{2,}|\#\{|^\.|\.$)|~/, '_')
   end
 
   def <=>(other)


### PR DESCRIPTION
I just made the change I need for my import -avoid '~'-, since I don't know what are valid darcs tag names but invalid git tag names, 

Reading man git-check-ref-format could give you the final improvement to this conversion

Thanks for the tool
