### PR TITLE
Replace usage of deprecated File.exists?

### DIFF
--- a/darcs-to-git
+++ b/darcs-to-git
@@ -239,7 +239,7 @@ class CommitHistory
   def initialize(patch_file_name)
     @patch_file_name = patch_file_name
     @darcs_patches_in_git = {}
-    if File.exists?(patch_file_name)
+    if File.exist?(patch_file_name)
       @darcs_patches_in_git = YAML.load_file(patch_file_name)
       unless @darcs_patches_in_git.is_a?(Hash)
         raise "yaml hash not found in #{patch_file_name}"
@@ -552,7 +552,7 @@ COMMIT_HISTORY = CommitHistory.new(GIT_PATCHES)
 
 AUTHOR_MAP = if OPTIONS[:author_map]
                AuthorMap.load(OPTIONS[:author_map])
-             elsif File.exists?(DEFAULT_AUTHOR_MAP_FILE)
+             elsif File.exist?(DEFAULT_AUTHOR_MAP_FILE)
                AuthorMap.load(DEFAULT_AUTHOR_MAP_FILE)
              else
                AuthorMap.new


### PR DESCRIPTION
File.exists? has been deprecated since Ruby 2.1.0, and it was finally removed in Ruby 3.2.0.
See: https://github.com/ruby/ruby/pull/5352

